### PR TITLE
fix: initialize emailjs and validate contact form end-to-end

### DIFF
--- a/components/apps/gedit.tsx
+++ b/components/apps/gedit.tsx
@@ -27,6 +27,7 @@ export class Gedit extends Component {
 
         if (publicKey && serviceID && templateID) {
             this.setState({ emailjsReady: true });
+            emailjs.init(publicKey);
             return;
         }
 


### PR DESCRIPTION
## Fix: Initialize EmailJS and end-to-end contact form validation

### Problem
- `emailjs.init(publicKey)` was never called in `componentDidMount`, which can cause the EmailJS browser SDK to fail silently in some environments
- GitHub secrets (`EMAILJS_SERVICE_ID`, `EMAILJS_TEMPLATE_ID`, `EMAILJS_PUBLIC_KEY`) are now correctly injected as `NEXT_PUBLIC_*` env vars via the workflow

### Changes
- Added `emailjs.init(publicKey)` call inside `componentDidMount` after verifying all env vars are present
- This ensures the EmailJS client is properly initialized before any `send()` calls

### Template Variables
The EmailJS template `template_4ltm9uh` should use these variables:
- `{{from_name}}` - sender's name
- `{{from_email}}` - sender's email
- `{{subject}}` - email subject
- `{{message}}` - message body
- `{{reply_to}}` - reply-to address (same as from_email)

### Testing
1. Deploy this branch and visit the live site
2. Open the Gedit/contact window
3. Fill in name, email, subject, message and click Send
4. Verify email arrives at `aman9893089064@gmail.com`